### PR TITLE
Set the token at the checkout stage

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          token: ${{ steps.token.outputs.token }}
 
       - uses: actions/setup-python@v4
         with:
@@ -148,7 +150,6 @@ jobs:
           
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          token: ${{ steps.token.outputs.token }}
           file_pattern: 'data.csv'
 
       - name: Upload data


### PR DESCRIPTION
As the documentation states (https://github.com/stefanzweifel/git-auto-commit-action#push-to-protected-branches) , the special APP token should be set at the checkout stage not at the commit stage.