### PR TITLE
Don't run benchmarks on push, so recursive workflow runs are avoided

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,8 +1,6 @@
 name: benchmarks
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: '0 */8 * * *' # Run workflow threee times a day


### PR DESCRIPTION
Normally, commits authored via `stefanzweifel/git-auto-commit-action` with the default GITHUB_TOKEN do not trigger workflow runs. Unfortunately, in our case we don't use the default token so we would have recursive workflow runs.