### PR TITLE
Workaround for errors due to a vulnerability scanning

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,9 +1,9 @@
 name: benchmarks
 
 on:
-  push:
-  pull_request:
-  
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */8 * * *' # Run workflow threee times a day
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,9 +1,9 @@
 name: benchmarks
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 */8 * * *' # Run workflow threee times a day
+  push:
+  pull_request:
+  
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/scripts/perftests/testCases/Orleans-eda972a.ps1
+++ b/scripts/perftests/testCases/Orleans-eda972a.ps1
@@ -19,7 +19,7 @@ $ProgressPreference = 'SilentlyContinue' #https://github.com/PowerShell/PowerShe
 if ($globalJsonPath) {Remove-Item "$sourcePath\$globalJsonPath"}
 
 #########################################################
-New-Item "$sourcePath\Directory.Build.rsp" -ItemType File -Value "\p:NuGetAudit=disable"
+New-Item "$sourcePath\Directory.Build.rsp" -ItemType File -Value "/p:NuGetAudit=disable"
 
 $versions = @("dotnet_base", "dotnet")
 ForEach ($version In $versions) {

--- a/scripts/perftests/testCases/Orleans-eda972a.ps1
+++ b/scripts/perftests/testCases/Orleans-eda972a.ps1
@@ -18,6 +18,9 @@ $solutionFilePath = "$sourcePath\$solutionFilePath"
 $ProgressPreference = 'SilentlyContinue' #https://github.com/PowerShell/PowerShell/issues/2138 
 if ($globalJsonPath) {Remove-Item "$sourcePath\$globalJsonPath"}
 
+#########################################################
+New-Item "$sourcePath\Directory.Build.rsp" -ItemType File -Value "\p:NuGetAudit=disable"
+
 $versions = @("dotnet_base", "dotnet")
 ForEach ($version In $versions) {
 	$url = (Get-Variable ("$version" + "_url")).Value

--- a/scripts/perftests/testCases/Orleans-eda972a.ps1
+++ b/scripts/perftests/testCases/Orleans-eda972a.ps1
@@ -19,6 +19,7 @@ $ProgressPreference = 'SilentlyContinue' #https://github.com/PowerShell/PowerShe
 if ($globalJsonPath) {Remove-Item "$sourcePath\$globalJsonPath"}
 
 #########################################################
+# Workaround for errors due to a vulnerability scanning (https://github.com/NuGet/Home/blob/dev/proposed/2022/vulnerabilities-in-restore.md)
 New-Item "$sourcePath\Directory.Build.rsp" -ItemType File -Value "/p:NuGetAudit=disable"
 
 $versions = @("dotnet_base", "dotnet")


### PR DESCRIPTION
Recently, this started to fail due to errors from vulnerability scanning during restore (See the https://github.com/NuGet/Home/blob/dev/proposed/2022/vulnerabilities-in-restore.md).