### PR TITLE
Run benchmarks on PRs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,8 @@ jobs:
   process_data:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    if: github.repository == 'G-Research/NuPerfMonitor' && github.ref == 'refs/heads/master' 
+    if: github.repository == 'G-Research/NuPerfMonitor' && github.ref == 'refs/heads/master'
+    environment: updater
     runs-on: ubuntu-latest
     needs: [benchmarks_windows, benchmarks_linux]
     steps:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,29 +20,12 @@ jobs:
           path: code
           
   benchmarks_linux:
-    strategy:
-      matrix:
-        test_script: [Orleans-eda972a]
-      fail-fast: false
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
           path: code
-
-      - name: Benchmark
-        shell: pwsh
-        run: |
-          .\code\scripts\perftests\testCases\${{matrix.test_script}}.ps1
-          Rename-Item -Path "results.csv" -NewName "${{matrix.test_script}}.csv"
-          
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{matrix.test_script}}
-          path: ${{matrix.test_script}}.csv
 
   process_data:
     # Only run on main repository

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   benchmarks_windows:
+  
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,7 +11,12 @@ env:
 
 jobs:
   benchmarks_windows:
-  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: code
+          
   benchmarks_linux:
     strategy:
       matrix:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
   process_data:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    if: github.ref == 'refs/heads/master' && github.repository == 'G-Research/NuPerfMonitor'
+    if: github.repository == 'G-Research/NuPerfMonitor' && github.ref == 'refs/heads/master' 
     runs-on: ubuntu-latest
     needs: [benchmarks_windows, benchmarks_linux]
     steps:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,34 +11,11 @@ env:
 
 jobs:
   benchmarks_windows:
-    strategy:
-      matrix:
-        test_script: [NuGetClient-win-d76a117]
-      fail-fast: false
-    runs-on: windows-latest
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          path: code
-
-      - name: Benchmark
-        shell: pwsh
-        run: |
-          .\code\scripts\perftests\testCases\${{matrix.test_script}}.ps1
-          Rename-Item -Path "results.csv" -NewName "${{matrix.test_script}}.csv"
-          
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{matrix.test_script}}
-          path: ${{matrix.test_script}}.csv
-          
+  
   benchmarks_linux:
     strategy:
       matrix:
-        test_script: [LargeAppCPM64-142722b, LargeAppCPM64-nostaticgraph-142722b, OrchardCore-5dbd92c, Orleans-eda972a]
+        test_script: [Orleans-eda972a]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -64,7 +41,6 @@ jobs:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
     if: github.repository == 'G-Research/NuPerfMonitor' && ${{github.ref == 'refs/heads/master' }}
-    environment: updater
     runs-on: ubuntu-latest
     needs: [benchmarks_windows, benchmarks_linux]
     steps:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,6 +2,7 @@ name: benchmarks
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     - cron: '0 */8 * * *' # Run workflow threee times a day
 env:
@@ -62,7 +63,6 @@ jobs:
   process_data:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    if: github.repository == 'G-Research/NuPerfMonitor'
     environment: updater
     runs-on: ubuntu-latest
     needs: [benchmarks_windows, benchmarks_linux]
@@ -125,7 +125,7 @@ jobs:
           fi
 
       - name: Create new issue if necessary
-        if: steps.alerts.outputs.file_exists == 'true'
+        if: steps.alerts.outputs.file_exists == 'true' && ${{github.ref == 'refs/heads/master' }}
         run: |
           numOpenIssues="$(gh api graphql -F owner=$OWNER -F name=$REPO -f query='
             query($name: String!, $owner: String!) {
@@ -147,6 +147,7 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           
       - uses: stefanzweifel/git-auto-commit-action@v4
+        if: ${{github.ref == 'refs/heads/master' }}
         with:
           file_pattern: 'data.csv'
           commit_author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,21 +11,54 @@ env:
 
 jobs:
   benchmarks_windows:
-  
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test_script: [NuGetClient-win-d76a117]
+      fail-fast: false
+    runs-on: windows-latest
     steps:
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
           path: code
+
+      - name: Benchmark
+        shell: pwsh
+        run: |
+          .\code\scripts\perftests\testCases\${{matrix.test_script}}.ps1
+          Rename-Item -Path "results.csv" -NewName "${{matrix.test_script}}.csv"
+          
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{matrix.test_script}}
+          path: ${{matrix.test_script}}.csv
           
   benchmarks_linux:
+    strategy:
+      matrix:
+        test_script: [LargeAppCPM64-142722b, LargeAppCPM64-nostaticgraph-142722b, OrchardCore-5dbd92c, Orleans-eda972a]
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
           path: code
+
+      - name: Benchmark
+        shell: pwsh
+        run: |
+          .\code\scripts\perftests\testCases\${{matrix.test_script}}.ps1
+          Rename-Item -Path "results.csv" -NewName "${{matrix.test_script}}.csv"
+          
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{matrix.test_script}}
+          path: ${{matrix.test_script}}.csv
 
   process_data:
     # Only run on main repository

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -63,6 +63,7 @@ jobs:
   process_data:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
+    if: github.repository == 'G-Research/NuPerfMonitor' && ${{github.ref == 'refs/heads/master' }}
     environment: updater
     runs-on: ubuntu-latest
     needs: [benchmarks_windows, benchmarks_linux]

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: Create new issue if necessary
-        if: steps.alerts.outputs.file_exists == 'true' && ${{github.ref == 'refs/heads/master' }}
+        if: steps.alerts.outputs.file_exists == 'true'
         run: |
           numOpenIssues="$(gh api graphql -F owner=$OWNER -F name=$REPO -f query='
             query($name: String!, $owner: String!) {
@@ -148,7 +148,6 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           
       - uses: stefanzweifel/git-auto-commit-action@v4
-        if: ${{github.ref == 'refs/heads/master' }}
         with:
           file_pattern: 'data.csv'
           commit_author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
   process_data:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    if: github.repository == 'G-Research/NuPerfMonitor' && ${{github.ref == 'refs/heads/master' }}
+    if: github.ref == 'refs/heads/master' && github.repository == 'G-Research/NuPerfMonitor'
     runs-on: ubuntu-latest
     needs: [benchmarks_windows, benchmarks_linux]
     steps:


### PR DESCRIPTION
This change lets us run benchmarks on pull requests. It will make it easier to test changes that aim to fix or modify the benchmark runs.
 