### PR TITLE
Use 'main' instead of 'master' branch

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -63,7 +63,7 @@ jobs:
   process_data:
     # Only run on main repository
     # Scheduled workflows do not have information about fork status, hence the hardcoded check
-    if: github.repository == 'G-Research/NuPerfMonitor' && github.ref == 'refs/heads/master'
+    if: github.repository == 'G-Research/NuPerfMonitor' && github.ref == 'refs/heads/main'
     environment: updater
     runs-on: ubuntu-latest
     needs: [benchmarks_windows, benchmarks_linux]


### PR DESCRIPTION
Fixing a bug introduced with the last change. We use "main" branch in this repository.
