### PR TITLE
add dependabot config for python and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
The goal of this PR is to provide regular updates for pip packages and GitHub actions used in this repo with enabling dependabot on the repo with simple config in this PR