### PR TITLE
Revert "enable basic python linting"

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -110,11 +110,6 @@ jobs:
         run: |
           Get-ChildItem -File -Path artifacts -Depth 1 | Foreach {. python3 process_results.py $_.fullname data.csv}
 
-      - name: Lint - Python
-        shell: pwsh
-        run: |
-          pylint *.py
-
       - name: Generate graph with Plotly for Python
         if: ${{ false }}
         shell: pwsh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pylint
 plotly
 pandas


### PR DESCRIPTION
Reverts G-Research/NuPerfMonitor#23

@ljubon running pylint in benchmarks workflow is not a good idea.
Benchmarks workflow runs only on the main branch and we don't want that workflow to fail because of formatting issues. We need a new workflow with pylint that runs on the main branch and also on PRs.