### PR TITLE
OSS-125: Enable GitHub Release 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,5 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ncipollo/release-action@v1
+      with:
+        tag: ${{ github.GITHUB_REF_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  Release:
+  release:
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,4 +15,4 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ncipollo/release-action@v1
       with:
-        tag: ${{ github.GITHUB_REF_NAME }}
+        tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+
+  Release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ncipollo/release-action@v1


### PR DESCRIPTION
The goal of this PR is to enable the basic GitHub release process with publishing tags in the format of `v*`

[Example workflow](https://github.com/ljubon/NuPerfMonitor/actions/runs/7886733828/job/21520528721) and [Example release](https://github.com/ljubon/NuPerfMonitor/releases/tag/v0.0.6-dev)
