### PR TITLE
ci: update ncipollo/release-action trailing comment for node24 cutover

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-    - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
+    - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
       with:
         tag: ${{ github.ref_name }}


### PR DESCRIPTION
GitHub forces `using: node20` JS actions to Node 24 on 2026-06-02.

`ncipollo/release-action`'s `v1` tag was rebased to the `v1.21.0` release on 2026-03-14, which declares `using: node24`. The pinned SHA didn't change — only the trailing comment is updated to reflect the new resolved version.