### PR TITLE
Fix Pages deployment branch trigger

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- update the Pages deployment workflow to run on pushes to the default `main` branch
- keep manual workflow dispatch and the existing deployment steps unchanged

## Remote Linux validation
- `git diff --check`
- parsed `.github/workflows/site.yml` with Ruby YAML
- confirmed the upstream default branch is `main`